### PR TITLE
Fix zero install report on Android

### DIFF
--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java
@@ -58,10 +58,15 @@ public class CodePush implements ReactPackage {
         return mServerUrl;
     }
 
-    public CodePush(String deploymentKey, Context context, boolean isDebugMode) {
+    public CodePush(String deploymentKey, String assetsBundleFileName, Context context, boolean isDebugMode) {
         mContext = context.getApplicationContext();
-
         mUpdateManager = new CodePushUpdateManager(context.getFilesDir().getAbsolutePath());
+
+        if(assetsBundleFileName != null) {
+            this.mAssetsBundleFileName = assetsBundleFileName;
+            mUpdateManager.setAssetsBundleFileName(assetsBundleFileName);
+        }
+
         mTelemetryManager = new CodePushTelemetryManager(mContext, this);
         mDeploymentKey = deploymentKey;
         mIsDebugMode = isDebugMode;
@@ -86,6 +91,10 @@ public class CodePush implements ReactPackage {
 
         clearDebugCacheIfNeeded(null);
         initializeUpdateAfterRestart();
+    }
+
+    public CodePush(String deploymentKey, Context context, boolean isDebugMode) {
+        this(deploymentKey, null, context, isDebugMode);
     }
 
     public CodePush(String deploymentKey, Context context, boolean isDebugMode, String serverUrl) {
@@ -226,7 +235,10 @@ public class CodePush implements ReactPackage {
     }
 
     public String getJSBundleFile() {
-        return getJSBundleFile(CodePushConstants.DEFAULT_JS_BUNDLE_NAME);
+        if (mAssetsBundleFileName == null) {
+            return getJSBundleFile(CodePushConstants.DEFAULT_JS_BUNDLE_NAME);
+        }
+        return getJSBundleFile(mAssetsBundleFileName);
     }
 
     public String getJSBundleFile(String assetsBundleFileName) {

--- a/android/app/src/main/java/com/microsoft/codepush/react/CodePushBuilder.java
+++ b/android/app/src/main/java/com/microsoft/codepush/react/CodePushBuilder.java
@@ -9,6 +9,7 @@ public class CodePushBuilder {
     private boolean mIsDebugMode;
     private String mServerUrl;
     private Integer mPublicKeyResourceDescriptor;
+    private String mJsBundleName = CodePushConstants.DEFAULT_JS_BUNDLE_NAME;
 
     public CodePushBuilder(String deploymentKey, Context context) {
         this.mDeploymentKey = deploymentKey;
@@ -31,7 +32,12 @@ public class CodePushBuilder {
         return this;
     }
 
+    public CodePushBuilder setJsBundleName(String jsBundleName) {
+        this.mJsBundleName = jsBundleName;
+        return this;
+    }
+
     public CodePush build() {
-        return new CodePush(this.mDeploymentKey, this.mContext, this.mIsDebugMode, this.mServerUrl, this.mPublicKeyResourceDescriptor);
+        return new CodePush(this.mDeploymentKey, this.mJsBundleName, this.mContext, this.mIsDebugMode, this.mServerUrl, this.mPublicKeyResourceDescriptor);
     }
 }


### PR DESCRIPTION
```
this.mAssetsBundleFileName = assetsBundleFileName;
mUpdateManager.setAssetsBundleFileName(assetsBundleFileName);
```

These two lines are previously called on [getJsBundleFile](https://github.com/traveloka/react-native-code-push/blob/feature/splits/v6.1.0/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java#L241-L242), when the code wants to load bundles. However, `mUpdateManager` needs the assets name on instantiating CodePush when calling [`mUpdateManager.getCurrentPackage()`](https://github.com/traveloka/react-native-code-push/blob/feature/splits/v6.1.0/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java#L290) to check whether the current package is up to date or not. As the assets name has not been set yet, the method will always return null.

**Note:** I tried to make the changes as small as possible and not breaking the default CodePush implementation.