### PR TITLE
Update validation for loading bundle

### DIFF
--- a/ios/CodePush/CodePush.h
+++ b/ios/CodePush/CodePush.h
@@ -207,6 +207,7 @@ failCallback:(void (^)(NSError *err))failCallback;
 
 + (NSString *)manifestFolderPrefix;
 + (NSString *)modifiedDateStringOfFileAtURL:(NSURL *)fileURL;
++ (BOOL)isBinaryBundle:(NSURL *)binaryBundleURL olderThanPackageDate:(NSString *)packageDateString;
 
 + (BOOL)isHashIgnoredFor:(NSString *) relativePath;
 

--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -210,10 +210,11 @@ static NSString *const LatestRollbackCountKey = @"count";
         return binaryBundleURL;
     }
 
+    NSString *binaryDate = [CodePushUpdateUtils modifiedDateStringOfFileAtURL:binaryBundleURL];
     NSString *packageDate = [currentPackageMetadata objectForKey:BinaryBundleDateKey];
     NSString *packageAppVersion = [currentPackageMetadata objectForKey:AppVersionKey];
 
-    if ([[CodePushUpdateUtils modifiedDateStringOfFileAtURL:binaryBundleURL] isEqualToString:packageDate] && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
+    if ([CodePushUpdateUtils isBinaryBundle:binaryBundleURL olderThanPackageDate:packageDate] && ([CodePush isUsingTestConfiguration] ||[binaryAppVersion isEqualToString:packageAppVersion])) {
         // Return package file because it is newer than the app store binary's JS bundle
         NSURL *packageUrl = [[NSURL alloc] initFileURLWithPath:packageFile];
         CPLog(logMessageFormat, packageUrl);

--- a/ios/CodePush/CodePushUpdateUtils.m
+++ b/ios/CodePush/CodePushUpdateUtils.m
@@ -261,6 +261,18 @@ NSString * const IgnoreCodePushMetadata = @".codepushrelease";
     }
 }
 
++ (BOOL)isBinaryBundle:(NSURL *)binaryBundleURL olderThanPackageDate:(NSString *)packageDateString
+{
+    NSDate *binaryDate = [[NSDate alloc] initWithTimeIntervalSince1970:[self modifiedDateStringOfFileAtURL:binaryBundleURL].doubleValue];
+    NSDate *packageDate = [[NSDate alloc] initWithTimeIntervalSince1970:packageDateString.doubleValue];
+    NSComparisonResult result = [binaryDate compare:packageDate];
+    
+    if (result == NSOrderedSame || result == NSOrderedDescending) {
+        return YES;
+    }
+    return NO;
+}
+
 + (BOOL)verifyFolderHash:(NSString *)finalUpdateFolder
                    expectedHash:(NSString *)expectedHash
                           error:(NSError **)error


### PR DESCRIPTION
Instead of using exact date, we'll use bundle from CodePush when binary bundle's modified date is older or match with CodePush bundle